### PR TITLE
don't call `#destroy` if there is no `Setting.for('micropub_endpoint')`

### DIFF
--- a/db/migrate/20160225042735_delete_micropub_endpoint_setting.rb
+++ b/db/migrate/20160225042735_delete_micropub_endpoint_setting.rb
@@ -1,6 +1,6 @@
 class DeleteMicropubEndpointSetting < ActiveRecord::Migration
   def up
-    Setting.of("micropub_endpoint").destroy
+    Setting.of("micropub_endpoint")&.destroy
   end
   
   def down


### PR DESCRIPTION
This is blowing up new deployments since migrations run before seeds.

On that note, this will never run for new deployments, so we could probably do away with the entire migration. I went with this first because it was the least intrusive and you're using 2.3 so I got to use the Lonely Operator :tada: 

